### PR TITLE
ci: 中央テンプレの markdown-lint caller を導入する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/md-lint.yml
+++ b/.github/workflows/md-lint.yml
@@ -1,0 +1,29 @@
+name: Markdown Lint
+
+# tomio2480/github-workflows v2 の composite action を呼び出す caller workflow．
+# 参照は @<SHA> # <version> 形式の SHA pin で，Dependabot が更新 PR を起票する．
+# 設定の上書きが必要な場合はリポジトリルートに以下のいずれかを置けば優先される：
+#   .markdownlint-cli2.yaml / .textlintrc.json / prh.yml / .textlintignore
+# 詳細は https://github.com/tomio2480/github-workflows の README を参照．
+
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  lint:
+    name: Markdown Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Markdown Lint via composite action
+        uses: tomio2480/github-workflows/.github/actions/markdown-lint@20a93b5ca42235c26c13e742ccfcdee2ac999b99 # v2.6.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 📝 概要

全リポジトリの Markdown 品質チェックを統一するため，
中央テンプレ `tomio2480/github-workflows` の markdown-lint
composite action を呼び出す caller workflow を導入する．

## 📦 変更内容

- `.github/workflows/md-lint.yml` を追加する．
  参照は SHA pin（`20a93b5 # v2.6.0`）とし，PR の Markdown 変更時に発火する．
- `.github/dependabot.yml` が無い場合は github-actions ecosystem を追加し，
  SHA pin の更新 PR を Dependabot が起票できるようにする．

## 🔧 設定の上書き

リポジトリ固有の lint 設定が必要な場合は，ルートに
`.markdownlint-cli2.yaml` / `.textlintrc.json` / `prh.yml` /
`.textlintignore` を置けば優先される．
詳細は [tomio2480/github-workflows](https://github.com/tomio2480/github-workflows) の README を参照．

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - GitHub Actions関連の依存関係を週次で自動更新する仕組みを追加しました。
  - 自動作成される更新プルリクエスト数を最大5件に制限しました。

- **品質改善**
  - Markdownファイルを変更したプルリクエストで、自動的に書式チェックを実行するようにしました。
  - ドキュメントの品質を継続的に確認できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->